### PR TITLE
🐛 Fix SidebarItem Typo in Prop Passing

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -24,7 +24,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             href: '/',     
         },
         {   
-            search: BiSearch,
+            icon: BiSearch,
             label: 'Search',
             active: pathname === '/search',
             href: '/search',

--- a/components/SidebarItem.tsx
+++ b/components/SidebarItem.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import Link from 'next/link';
 import { IconType } from 'react-icons';
 import { twMerge } from 'tailwind-merge';
@@ -9,7 +11,7 @@ interface SidebarItemProps {
   href: string;
 };
 
-const SidebarItem: React.FC<SidebarItemProps> = ({
+const SidebarItem: React.FC<SidebarItemProps> = ({  
   icon: Icon,
   label,
   active,
@@ -36,6 +38,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
         )
       }
     >
+        
       <Icon size={26}/>
       <p className="truncate w-100">{label}</p>
     </Link>


### PR DESCRIPTION
This commit resolves #3 

Details:
🔍 **Issue Identified**:
Discovered a typo in the props passed to the Sidebar component, causing a TypeScript error in the SidebarItem. The incorrect prop name was causing the type mismatch error. 🚨

🛠️ **Resolution**:
Corrected the typo in the prop name being passed to the Sidebar component, ensuring accurate and matching prop names between components. TypeScript error resolved! 🎉

🔗 **Related Issues**: #SidebarItemError #TypoFix

🚀 Successfully resolved the TypeScript error caused by the typo in prop passing to the Sidebar component. Ready to continue development smoothly! 🎶✨
 